### PR TITLE
Threadmarks menu on single page threads

### DIFF
--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -152,6 +152,13 @@
     <a href="{xen:link 'threads/threadmarks', $threadmarks}" rel="nofollow" class="OverlayTrigger threadmarksTrigger">{xen:phrase threadmarks}</a>
   </xen:if>
 </xen:if>]]></template>
+    <template title="single_page_thread_threadmarks_menu" version_id="2" version_string="1.0"><![CDATA[<xen:if is="{$singlePageThread}">
+  <div class="PageNav threadmarksSinglePage">
+    <xen:include template="page_nav_threadmarks">
+      <xen:map from="$thread.threadmarks" to="$threadmarks"/>
+    </xen:include>
+  </div>
+</xen:if>]]></template>
     <template title="threadmarks" version_id="1" version_string="1.0"><![CDATA[<xen:title>{xen:phrase threadmarks_for}: {xen:helper threadPrefix, $thread, escaped}{$thread.title}</xen:title>
 
 <xen:h1>{xen:helper threadPrefix, $thread} {xen:phrase threadmarks_for}: {$thread.title}</xen:h1>
@@ -239,13 +246,7 @@ $0]]></replace>
     </modification>
     <modification template="thread_view" modification_key="sidaneThreadmarksMenuOnSinglePageThreads" description="Display threadmarks menu on single page threads" execution_order="10" enabled="1" action="str_replace">
       <find><![CDATA[<xen:pagenav]]></find>
-      <replace><![CDATA[<xen:if is="{$totalPosts} <= {$postsPerPage}">
-<div class="PageNav threadmarksSinglePage">
-  <xen:include template="page_nav_threadmarks">
-    <xen:map from="$thread.threadmarks" to="$threadmarks" />
-  </xen:include>
-</div>
-</xen:if>
+      <replace><![CDATA[<xen:include template="single_page_thread_threadmarks_menu"/>
 
 $0]]></replace>
     </modification>

--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -181,7 +181,12 @@
 
   <div class="sectionFooter overlayOnly"><a class="button primary OverlayCloser">{xen:phrase close}</a></div>
 </div>]]></template>
-    <template title="threadmarks.css" version_id="1" version_string="1.0"><![CDATA[.PageNav a.threadmarksTrigger {
+    <template title="threadmarks.css" version_id="2" version_string="1.0"><![CDATA[.PageNav.threadmarksSinglePage {
+  float: left;
+  min-width: 0;
+}
+
+.PageNav a.threadmarksTrigger {
   width: auto !important;
   padding-left: 4px;
   padding-right: 4px;
@@ -232,7 +237,19 @@ $0]]></replace>
 </xen:if>
 $0]]></replace>
     </modification>
-    <modification template="page_nav" modification_key="sidaneThreadmarksModification" description="Add threadmarks HTML after thread pagination links" execution_order="100" enabled="1" action="str_replace">
+    <modification template="thread_view" modification_key="sidaneThreadmarksMenuOnSinglePageThreads" description="Display threadmarks menu on single page threads" execution_order="10" enabled="1" action="str_replace">
+      <find><![CDATA[<xen:pagenav]]></find>
+      <replace><![CDATA[<xen:if is="{$totalPosts} <= {$postsPerPage}">
+<div class="PageNav threadmarksSinglePage">
+  <xen:include template="page_nav_threadmarks">
+    <xen:map from="$thread.threadmarks" to="$threadmarks" />
+  </xen:include>
+</div>
+</xen:if>
+
+$0]]></replace>
+    </modification>
+    <modification template="page_nav" modification_key="sidaneThreadmarksModification" description="Display threadmarks menu on multi-page threads" execution_order="100" enabled="1" action="str_replace">
       <find><![CDATA[</nav>]]></find>
       <replace><![CDATA[<xen:include template="page_nav_threadmarks">
   <xen:map from="$linkData.threadmarks" to="$threadmarks" />

--- a/upload/library/Sidane/Threadmarks/ControllerPublic/Thread.php
+++ b/upload/library/Sidane/Threadmarks/ControllerPublic/Thread.php
@@ -14,6 +14,7 @@ class Sidane_Threadmarks_ControllerPublic_Thread extends XFCP_Sidane_Threadmarks
     $threadmarksHelper = $this->_threadmarksHelper();
     $threadmarks = $threadmarksHelper->getThreadmarks($parent->params['thread']);
     if (!empty($threadmarks)) {
+      $parent->params['singlePageThread'] = $parent->params['totalPosts'] <= $parent->params['postsPerPage'];
       $parent->params['thread']['threadmarks'] = $threadmarks;
     }
 


### PR DESCRIPTION
Fixes issues #4 

**Note:** Currently contains [remove-template-hooks](https://github.com/Sidane/xenforo-threadmarks/pull/5) branch. View changes for just this branch: https://github.com/Sidane/xenforo-threadmarks/compare/remove-template-hooks...threadmarks-menu-on-single-page-threads
