### PR TITLE
Only fetch needed Threadmarks per page

### DIFF
--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -236,10 +236,8 @@
   }
 }
 </xen:if>]]></template>
-    <template title="threadmarks_render_flag" version_id="2" version_string="1.0"><![CDATA[<xen:if is="{$threadmarks} and {$threadmarkCategories} and {$post.canViewThreadmarks}">
-  <xen:foreach loop="$threadmarks" value="$threadmark">
-    <span class='threadmarker {$threadmarkCategories.{$threadmark.category}.css}' id='post-{$post.post_id}'><strong>{xen:phrase threadmark}:</strong> {$threadmark.label}</span>
-  </xen:foreach>
+    <template title="threadmarks_render_flag" version_id="2" version_string="1.0"><![CDATA[<xen:if is="{$threadmark} and {$post.canViewThreadmarks}">
+    <span class='threadmarker' id='post-{$post.post_id}'><strong>{xen:phrase threadmark}:</strong> {$threadmark.label}</span>
 </xen:if>]]></template>
   </templates>
   <public_template_modifications>
@@ -271,8 +269,7 @@ $0]]></replace>
     <modification template="message" modification_key="sidaneThreadmarksModification1" description="Add flag before threadmarked post" execution_order="10" enabled="1" action="str_replace">
       <find><![CDATA[<li id="{$messageId}"]]></find>
       <replace><![CDATA[<xen:include template="threadmarks_render_flag">
-  <xen:map from="$thread.threadmarkCategories" to="$threadmarkCategories" />
-  <xen:map from="$post.threadmarks" to="$threadmarks" />
+  <xen:map from="$post.threadmark" to="$threadmark" />
 </xen:include>
 $0]]></replace>
     </modification>

--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -237,7 +237,7 @@
 }
 </xen:if>]]></template>
     <template title="threadmarks_render_flag" version_id="2" version_string="1.0"><![CDATA[<xen:if is="{$threadmark} and {$post.canViewThreadmarks}">
-    <span class='threadmarker' id='post-{$post.post_id}'><strong>{xen:phrase threadmark}:</strong> {$threadmark.label}</span>
+  <span class='threadmarker' id='post-{$post.post_id}'><strong>{xen:phrase threadmark}:</strong> {$threadmark.label}</span>
 </xen:if>]]></template>
   </templates>
   <public_template_modifications>

--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="sidaneThreadmarks" title="Threadmarks" version_string="1.0" version_id="2" url="" install_callback_class="Sidane_Threadmarks_Install" install_callback_method="install" uninstall_callback_class="Sidane_Threadmarks_Install" uninstall_callback_method="uninstall">
+<addon addon_id="sidaneThreadmarks" title="Threadmarks" version_string="1.0" version_id="3" url="" install_callback_class="Sidane_Threadmarks_Install" install_callback_method="install" uninstall_callback_class="Sidane_Threadmarks_Install" uninstall_callback_method="uninstall">
   <admin_navigation/>
   <admin_permissions/>
   <admin_style_properties/>
@@ -154,13 +154,13 @@
       </div>
     </div>
   <xen:else/>
-    <a href="{xen:link 'threads/threadmarks', $linkData}" rel="nofollow" class="OverlayTrigger threadmarksTrigger">{xen:phrase threadmarks}</a>
+    <a href="{xen:link 'threads/threadmarks', $threadmarks}" rel="nofollow" class="OverlayTrigger threadmarksTrigger">{xen:phrase threadmarks}</a>
   </xen:if>
 </xen:if>]]></template>
     <template title="single_page_thread_threadmarks_menu" version_id="2" version_string="1.0"><![CDATA[<xen:if is="{$singlePageThread}">
   <div class="PageNav threadmarksSinglePage">
     <xen:include template="page_nav_threadmarks">
-      <xen:map from="$thread.threadmarks" to="$threadmarks"/>
+      <xen:map from="$thread.recentThreadmarks" to="$threadmarks"/>
       <xen:map from="$thread" to="$linkData"/>
     </xen:include>
   </div>
@@ -236,8 +236,10 @@
   }
 }
 </xen:if>]]></template>
-    <template title="threadmarks_render_flag" version_id="2" version_string="1.0"><![CDATA[<xen:if is="{$threadmark} and {$post.canViewThreadmarks}">
-  <span class='threadmarker' id='post-{$post.post_id}'><strong>{xen:phrase threadmark}:</strong> {$threadmark.label}</span>
+    <template title="threadmarks_render_flag" version_id="2" version_string="1.0"><![CDATA[<xen:if is="{$threadmarks} and {$threadmarkCategories} and {$post.canViewThreadmarks}">
+  <xen:foreach loop="$threadmarks" value="$threadmark">
+    <span class='threadmarker {$threadmarkCategories.{$threadmark.category}.css}' id='post-{$post.post_id}'><strong>{xen:phrase threadmark}:</strong> {$threadmark.label}</span>
+  </xen:foreach>
 </xen:if>]]></template>
   </templates>
   <public_template_modifications>
@@ -262,14 +264,15 @@ $0]]></replace>
     <modification template="page_nav" modification_key="sidaneThreadmarksModification" description="Display threadmarks menu on multi-page threads" execution_order="100" enabled="1" action="str_replace">
       <find><![CDATA[</nav>]]></find>
       <replace><![CDATA[<xen:include template="page_nav_threadmarks">
-  <xen:map from="$linkData.threadmarks" to="$threadmarks" />
+  <xen:map from="$linkData.recentThreadmarks" to="$threadmarks" />
 </xen:include>
 $0]]></replace>
     </modification>
     <modification template="message" modification_key="sidaneThreadmarksModification1" description="Add flag before threadmarked post" execution_order="10" enabled="1" action="str_replace">
       <find><![CDATA[<li id="{$messageId}"]]></find>
       <replace><![CDATA[<xen:include template="threadmarks_render_flag">
-  <xen:map from="$thread.threadmarks.all.{$post.post_id}" to="$threadmark" />
+  <xen:map from="$thread.threadmarkCategories" to="$threadmarkCategories" />
+  <xen:map from="$post.threadmarks" to="$threadmarks" />
 </xen:include>
 $0]]></replace>
     </modification>

--- a/upload/library/Sidane/Threadmarks/ControllerHelper/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/ControllerHelper/Threadmarks.php
@@ -3,7 +3,7 @@
 class Sidane_Threadmarks_ControllerHelper_Threadmarks extends XenForo_ControllerHelper_Abstract
 {
 
-  public function getThreadmarks($thread) {
+  public function getRecentThreadmarks($thread) {
   
     if (!empty($thread['threadmark_count'])) {
       $threadmarksModel = $this->_controller->getModelFromCache('Sidane_Threadmarks_Model_Threadmarks');
@@ -15,7 +15,7 @@ class Sidane_Threadmarks_ControllerHelper_Threadmarks extends XenForo_Controller
 
       $threadmarksParams = array();
 
-      $threadmarks = $threadmarksModel->getByThreadId($thread['thread_id']);
+      $threadmarks = $threadmarksModel->getRecentByThreadId($thread['thread_id'],  0, $menuLimit + 1);
       $totalThreadmarks = count($threadmarks);
 
       if ($totalThreadmarks == 0) {
@@ -35,9 +35,8 @@ class Sidane_Threadmarks_ControllerHelper_Threadmarks extends XenForo_Controller
         $recentThreadmarks = $threadmarks;
       }
 
-      $threadmarksParams['all'] = $threadmarks;
       $threadmarksParams['recent'] = $recentThreadmarks;
-      $threadmarksParams['count'] = $totalThreadmarks;
+      $threadmarksParams['count'] = $thread['threadmark_count'];
 
       $threadmarksParams['threadmarks_post_ids'] = array_map(function($threadmark) {
         return $threadmark['post_id'];

--- a/upload/library/Sidane/Threadmarks/ControllerHelper/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/ControllerHelper/Threadmarks.php
@@ -15,7 +15,7 @@ class Sidane_Threadmarks_ControllerHelper_Threadmarks extends XenForo_Controller
 
       $threadmarksParams = array();
 
-      $threadmarks = $threadmarksModel->getRecentByThreadId($thread['thread_id'],  0, $menuLimit + 1);
+      $threadmarks = $threadmarksModel->getRecentByThreadId($thread['thread_id'], $menuLimit + 1);
       $totalThreadmarks = count($threadmarks);
 
       if ($totalThreadmarks == 0) {
@@ -29,13 +29,13 @@ class Sidane_Threadmarks_ControllerHelper_Threadmarks extends XenForo_Controller
       $threadmarksParams['logged_in'] = XenForo_Visitor::getUserId() != 0;
 
       if ($totalThreadmarks > $menuLimit) {
-        $recentThreadmarks = array_slice($threadmarks, $totalThreadmarks - $menuLimit, null, true);
+        $recentThreadmarks = array_slice($threadmarks, 0, $menuLimit, true);
         $threadmarksParams['more_threadmarks'] = true;
       } else {
         $recentThreadmarks = $threadmarks;
       }
 
-      $threadmarksParams['recent'] = $recentThreadmarks;
+      $threadmarksParams['recent'] = array_reverse($recentThreadmarks);
       $threadmarksParams['count'] = $thread['threadmark_count'];
 
       $threadmarksParams['threadmarks_post_ids'] = array_map(function($threadmark) {

--- a/upload/library/Sidane/Threadmarks/ControllerPublic/Thread.php
+++ b/upload/library/Sidane/Threadmarks/ControllerPublic/Thread.php
@@ -30,11 +30,6 @@ class Sidane_Threadmarks_ControllerPublic_Thread extends XFCP_Sidane_Threadmarks
       $parent->params['thread']['recentThreadmarks'] = $recentThreadmarks;
     }
 
-    if (!empty($parent->params['thread']['threadmark_count'])) { 
-      $threadmarksModel = $this->_getThreadmarksModel();
-      $parent->params['thread']['threadmarkCategories'] = $threadmarksModel->getThreadmarkTypes();
-    }
-
     return $parent;
   }
 

--- a/upload/library/Sidane/Threadmarks/Install.php
+++ b/upload/library/Sidane/Threadmarks/Install.php
@@ -90,6 +90,7 @@ class Sidane_Threadmarks_Install
 
   public static function uninstall()
   {
+/*  
     $db = XenForo_Application::get('db');
     if ($db->fetchRow("SHOW COLUMNS FROM xf_thread WHERE Field = ?", 'threadmark_count'))
     {
@@ -110,5 +111,6 @@ class Sidane_Threadmarks_Install
     $db->delete('xf_permission_entry_content', "permission_id = 'sidane_tm_edit'");
     $db->delete('xf_permission_entry_content', "permission_id = 'sidane_tm_menu_limit'");
     $db->delete('xf_permission_entry_content', "permission_id = 'sidane_tm_view'");
+*/    
   }
 }

--- a/upload/library/Sidane/Threadmarks/Install.php
+++ b/upload/library/Sidane/Threadmarks/Install.php
@@ -90,7 +90,6 @@ class Sidane_Threadmarks_Install
 
   public static function uninstall()
   {
-/*  
     $db = XenForo_Application::get('db');
     if ($db->fetchRow("SHOW COLUMNS FROM xf_thread WHERE Field = ?", 'threadmark_count'))
     {
@@ -111,6 +110,5 @@ class Sidane_Threadmarks_Install
     $db->delete('xf_permission_entry_content', "permission_id = 'sidane_tm_edit'");
     $db->delete('xf_permission_entry_content', "permission_id = 'sidane_tm_menu_limit'");
     $db->delete('xf_permission_entry_content', "permission_id = 'sidane_tm_view'");
-*/    
   }
 }

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -36,16 +36,10 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
 
     if (!empty($post['threadmark_id']))
     {    
-      // in the future cache the list of threadmarks associated with a post as a comma separated list
-      // for now only support 1 type.
-      $post['threadmarks'] = array
+      $post['threadmark'] = array
       (
-        array
-        (
-          'type' => 1,
-          'threadmark_id' => $post['threadmark_id'],
-          'label' => $post['threadmark_label'],
-        )
+        'threadmark_id' => $post['threadmark_id'],
+        'label' => $post['threadmark_label'],
       );
       unset($post['threadmark_id']);
       unset($post['threadmark_label']);

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -3,6 +3,26 @@
 
 class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
 {
+  const FETCH_THREADMARKS = 0x80000; // hope this doesn't conflict
+
+  public function preparePostJoinOptions(array $fetchOptions)
+  {
+    $joinOptions = parent::preparePostJoinOptions($fetchOptions);
+
+    if (!empty($fetchOptions['join']))
+    {
+      if ($fetchOptions['join'] & Sidane_Threadmarks_Model_Post::FETCH_THREADMARKS)
+      {
+        $joinOptions['selectFields'] .= ',
+          threadmarks.threadmark_id, threadmarks.label as threadmark_label';
+        $joinOptions['joinTables'] .= '
+          LEFT JOIN threadmarks  ON
+          (threadmarks.thread_id = post.thread_id && threadmarks.post_id = post.post_id)';        
+      }
+    }
+
+    return $joinOptions;
+  }
 
   public function preparePost(array $post, array $thread, array $forum, array $nodePermissions = null, array $viewingUser = null)
   {
@@ -13,6 +33,23 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
     $post['canEditThreadmarks'] = $threadmarkmodel->canEditThreadmark($post, $thread, $forum, $null, $nodePermissions, $viewingUser);
     $post['canDeleteThreadmarks'] = $threadmarkmodel->canDeleteThreadmark($post, $thread, $forum, $null, $nodePermissions, $viewingUser);
     $post['canViewThreadmarks'] = $threadmarkmodel->canViewThreadmark($thread, $null, $nodePermissions, $viewingUser);
+
+    if (!empty($post['threadmark_id']))
+    {    
+      // in the future cache the list of threadmarks associated with a post as a comma separated list
+      // for now only support 1 type.
+      $post['threadmarks'] = array
+      (
+        array
+        (
+          'type' => 1,
+          'threadmark_id' => $post['threadmark_id'],
+          'label' => $post['threadmark_label'],
+        )
+      );
+      unset($post['threadmark_id']);
+      unset($post['threadmark_label']);
+    }
 
     return $post;
   }

--- a/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
@@ -204,7 +204,7 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
       FROM threadmarks
       JOIN xf_post AS post ON post.post_id = threadmarks.post_id
       WHERE threadmarks.thread_id = ? and post.message_state = 'visible'
-      ORDER BY post.position ASC
+      ORDER BY post.position DESC
     ",$limit, $offset), 'post_id', $threadId);
   }
 

--- a/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
@@ -198,14 +198,14 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
     ",$limit, $offset));
   }
 
-  public function getByThreadId($threadId) {
-    return $this->fetchAllKeyed("
+  public function getRecentByThreadId($threadId, $limit = 0, $offset = 0) {
+    return $this->fetchAllKeyed($this->limitQueryResults("
       SELECT threadmarks.*
       FROM threadmarks
       JOIN xf_post AS post ON post.post_id = threadmarks.post_id
       WHERE threadmarks.thread_id = ? and post.message_state = 'visible'
       ORDER BY post.position ASC
-    ", 'post_id', $threadId);
+    ",$limit, $offset), 'post_id', $threadId);
   }
 
   public function getByThreadIdAndPostId($threadId, $postId) {
@@ -225,5 +225,19 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
       WHERE threadmarks.thread_id = ? and post.message_state = 'visible'
       ORDER BY post.position ASC
     ", 'post_id', $threadId);
+  }
+
+  public function getThreadmarkTypes() {
+    // in the future this would be dynamically queried to permit user provided threadmark labels
+    return array
+      (
+        1 => array
+        (
+          'threadmarktype_id' => 1,
+          'primary' => 0,
+          'css' => '',
+          'label' => 'threadmark',
+        )
+      );
   }
 }

--- a/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
@@ -226,18 +226,4 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
       ORDER BY post.position ASC
     ", 'post_id', $threadId);
   }
-
-  public function getThreadmarkTypes() {
-    // in the future this would be dynamically queried to permit user provided threadmark labels
-    return array
-      (
-        1 => array
-        (
-          'threadmarktype_id' => 1,
-          'primary' => 0,
-          'css' => '',
-          'label' => 'threadmark',
-        )
-      );
-  }
 }


### PR DESCRIPTION
Addresses issue #2, by ensuring that only the menu limit + current page's threadmarks are fetched.

Primary use-case for this is when users have a single thread with 300-600 threadmarks. I also may need to consider a better interface for adding hundreds of threadmarks to a thread.
