### PR TITLE
Handle when posts with threadmarks are moved between threads.

### DIFF
--- a/upload/library/Sidane/Threadmarks/Deferred/Cache.php
+++ b/upload/library/Sidane/Threadmarks/Deferred/Cache.php
@@ -1,11 +1,11 @@
 <?php
-  
+
 
 class Sidane_Threadmarks_Deferred_Cache extends XenForo_Deferred_Abstract
 {
-  
+
   const PER_PAGE = 5000;
-    
+
   public function execute(array $deferred, array $data, $targetRunTime, &$status)
   {
     $data = array_merge(array(
@@ -13,30 +13,37 @@ class Sidane_Threadmarks_Deferred_Cache extends XenForo_Deferred_Abstract
     ), $data);
 
     /** @var XenForo_Model_Post */
-    $threadMarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');   
-                
-    $threadIds = $threadMarkModel->getThreadIdsWithThreadMarks($data['page'], self::PER_PAGE);
-    
+    $threadMarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
+
+    if (isset($data['threadId'])
+    {
+      $threadIds = array($data['threadId']);
+    }
+    else
+    {
+      $threadIds = $threadMarkModel->getThreadIdsWithThreadMarks($data['page'], self::PER_PAGE);
+    }
+
     if(empty($threadIds))
       return false;
-      
+
     foreach($threadIds as $threadId)
     {
       $threadMarkModel->rebuildThreadMarkCache($threadId);
-    }        
-        
+    }
+
     $rbPhrase = new XenForo_Phrase('rebuilding');
     $typePhrase = new XenForo_Phrase('sidane_threadmarks_cache');
     $status = sprintf('%s... %s (%s)', $rbPhrase, $typePhrase, XenForo_Locale::numberFormat($data['page'] * self::PER_PAGE));
 
     $data['page'] ++;
-    
-    return $data;        
+
+    return $data;
   }
 
 
   public function canCancel()
     {
     return true;
-  }    
+  }
 }

--- a/upload/library/Sidane/Threadmarks/Deferred/Cache.php
+++ b/upload/library/Sidane/Threadmarks/Deferred/Cache.php
@@ -15,14 +15,7 @@ class Sidane_Threadmarks_Deferred_Cache extends XenForo_Deferred_Abstract
     /** @var XenForo_Model_Post */
     $threadMarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
 
-    if (isset($data['threadId'])
-    {
-      $threadIds = array($data['threadId']);
-    }
-    else
-    {
-      $threadIds = $threadMarkModel->getThreadIdsWithThreadMarks($data['page'], self::PER_PAGE);
-    }
+    $threadIds = $threadMarkModel->getThreadIdsWithThreadMarks($data['page'], self::PER_PAGE);
 
     if(empty($threadIds))
       return false;
@@ -43,7 +36,7 @@ class Sidane_Threadmarks_Deferred_Cache extends XenForo_Deferred_Abstract
 
 
   public function canCancel()
-    {
+  {
     return true;
   }
 }

--- a/upload/library/Sidane/Threadmarks/Deferred/SingleThreadCache.php
+++ b/upload/library/Sidane/Threadmarks/Deferred/SingleThreadCache.php
@@ -1,0 +1,27 @@
+<?php
+
+
+class Sidane_Threadmarks_Deferred_SingleThreadCache extends XenForo_Deferred_Abstract
+{
+  public function execute(array $deferred, array $data, $targetRunTime, &$status)
+  {
+    if (!isset($data['threadId']))
+    {
+      return false;
+    }
+
+    /** @var XenForo_Model_Post */
+    $threadMarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
+
+    $threadMarkModel->rebuildThreadMarkCache($data['threadId']);
+
+
+    return false;
+  }
+
+
+  public function canCancel()
+  {
+    return false;
+  }
+}

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -17,6 +17,12 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
     return $post;
   }
 
+  public function recalculatePostPositionsInThread($threadId)
+  {
+    XenForo_Application::defer('Sidane_Threadmarks_Deferred_Cache', array('threadId' => $threadId), null, true);    
+    return recalculatePostPositionsInThread($threadId)
+  }
+
   protected function _getThreadmarksModel() {
     return $this->getModelFromCache('Sidane_Threadmarks_Model_Threadmarks');
   }

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -19,8 +19,8 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
 
   public function recalculatePostPositionsInThread($threadId)
   {
-    XenForo_Application::defer('Sidane_Threadmarks_Deferred_Cache', array('threadId' => $threadId), null, true);    
-    return recalculatePostPositionsInThread($threadId)
+    $this->_getThreadmarksModel()->recalculatePostPositionsInThread($threadId);
+    return parent::recalculatePostPositionsInThread($threadId);
   }
 
   protected function _getThreadmarksModel() {

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -19,7 +19,7 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
 
   public function recalculatePostPositionsInThread($threadId)
   {
-    $this->_getThreadmarksModel()->recalculatePostPositionsInThread($threadId);
+    $this->_getThreadmarksModel()->recalculatePositionsInThread($threadId);
     return parent::recalculatePostPositionsInThread($threadId);
   }
 

--- a/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
@@ -196,10 +196,15 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
     ", $thread_id);
   }
 
+  public function recalculatePostPositionsInThread($threadId)
+  {
+    XenForo_Application::defer('Sidane_Threadmarks_Deferred_SingleThreadCache', array('threadId' => $threadId), null, true);    
+  }
+
   public function getThreadIdsWithThreadMarks($limit =0, $offset = 0)
   {
     $db = $this->_getDb();
-    return $db->fetchAll($this->limitQueryResults("
+    return $db->fetchCol($this->limitQueryResults("
       SELECT distinct thread_id
       FROM threadmarks
       ORDER BY threadmarks.thread_id ASC

--- a/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
@@ -196,7 +196,7 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
     ", $thread_id);
   }
 
-  public function recalculatePostPositionsInThread($threadId)
+  public function recalculatePositionsInThread($threadId)
   {
     XenForo_Application::defer('Sidane_Threadmarks_Deferred_SingleThreadCache', array('threadId' => $threadId), null, true);    
   }

--- a/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
@@ -169,13 +169,21 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
   {
     $db = $this->_getDb();
 
-    // remove orphaned threadmarks
+    // remove orphaned threadmarks (by post)
     $db->query('
         DELETE `threadmarks`
         FROM `threadmarks`
-        LEFT JOIN xf_post AS post on post.thread_id = threadmarks.thread_id and post.post_id = threadmarks.post_id
+        LEFT JOIN xf_post AS post on post.post_id = threadmarks.post_id
         where `threadmarks`.thread_id = ? and post.post_id is null;
     ', $thread_id);
+    
+    // ensure each threadmark associated with the thread really is
+    $db->query('
+        update `threadmarks` marks
+        join xf_post AS post on post.post_id = marks.post_id
+        set marks.thread_id = post.thread_id
+        where (post.thread_id = ? or marks.thread_id = ?) and post.thread_id <> marks.thread_id;
+    ', array($thread_id,$thread_id));
 
     // recompute threadmark totals
     $db->query("


### PR DESCRIPTION
With the thread_id cached in the threadmarks table, moving between threads will break things.
