### PR TITLE
Post Positions recomputing fix

### DIFF
--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -50,8 +50,9 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
 
   public function recalculatePostPositionsInThread($threadId)
   {
+    $ret = parent::recalculatePostPositionsInThread($threadId);
     $this->_getThreadmarksModel()->recalculatePositionsInThread($threadId);
-    return parent::recalculatePostPositionsInThread($threadId);
+    return $ret;
   }
 
   protected function _getThreadmarksModel() {


### PR DESCRIPTION
When a post is moved to a new thread, fixing up the threadmark position must wait till the posts finish being moved.
