### PR TITLE
Clickable threadmarks button

### DIFF
--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -132,7 +132,7 @@
     <template title="page_nav_threadmarks" version_id="3" version_string="1.0"><![CDATA[<xen:if is="{$threadmarks}">
   <xen:if is="{$threadmarks.logged_in} OR {$threadmarks.hide_menu_from_guests} != '1'">
     <div class="Popup threadmarks JsOnly">
-      <a rel="Menu" class="threadmarksTrigger">{xen:phrase threadmarks}</a>
+      <a href="{xen:link 'threads/threadmarks', $linkData}" rel="Menu" class="OverlayTrigger threadmarksTrigger">{xen:phrase threadmarks}</a>
       <div class="Menu threadmarksMenu">
         <xen:if is="{$threadmarks.more_threadmarks}">
           <div class="primaryContent menuHeader">


### PR DESCRIPTION
Clicking threadmarks button should open all threadmarks overlay. Consistent with other XF drop down menus.

Fixes #33.
