### PR TITLE
Make moderator log entries more useful

### DIFF
--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -40,6 +40,9 @@
     <phrase title="add_threadmark" version_id="1" version_string="1.0"><![CDATA[Add Threadmark]]></phrase>
     <phrase title="delete_threadmark" version_id="1" version_string="1.0"><![CDATA[Delete this threadmark]]></phrase>
     <phrase title="edit_threadmark" version_id="1" version_string="1.0"><![CDATA[Edit Threadmark]]></phrase>
+    <phrase title="moderator_log_post_create_threadmark" version_id="3" version_string="1.1"><![CDATA[Threadmark '{label}' created]]></phrase>
+    <phrase title="moderator_log_post_delete_threadmark" version_id="3" version_string="1.1"><![CDATA[Threadmark '{label}' deleted]]></phrase>
+    <phrase title="moderator_log_post_update_threadmark" version_id="3" version_string="1.1"><![CDATA[Threadmark changed from '{old_label}' to '{new_label}']]></phrase>
     <phrase title="most_recent_threadmarks" version_id="1" version_string="1.0"><![CDATA[Most recent threadmarks]]></phrase>
     <phrase title="option_group_sidaneThreadmarks" version_id="1" version_string="1.0"><![CDATA[Threadmarks]]></phrase>
     <phrase title="option_group_sidaneThreadmarks_description" version_id="1" version_string="1.0"><![CDATA[]]></phrase>

--- a/upload/library/Sidane/Threadmarks/ControllerPublic/Post.php
+++ b/upload/library/Sidane/Threadmarks/ControllerPublic/Post.php
@@ -28,14 +28,18 @@ class Sidane_Threadmarks_ControllerPublic_Post extends XFCP_Sidane_Threadmarks_C
           }
           $threadmarksModel->deleteThreadmark($existingThreadmark);
           $phrase = 'threadmark_deleted';
-          XenForo_Model_Log::logModeratorAction('post', $post, 'delete_threadmark', array(), $thread);
+          XenForo_Model_Log::logModeratorAction(
+            'post', $post, 'delete_threadmark', array('label' => $existingThreadmark['label']), $thread
+          );
         } else {
           if (!$threadmarksModel->canEditThreadmark($post, $thread, $forum)) {
             throw $this->getErrorOrNoPermissionResponseException('you_do_not_have_permission_to_edit_threadmarks');
           }
           $threadmarksModel->setThreadMark($thread['thread_id'], $post['post_id'], $label);
           $phrase = 'threadmark_updated';
-          XenForo_Model_Log::logModeratorAction('post', $post, 'update_threadmark', array(), $thread);
+          XenForo_Model_Log::logModeratorAction(
+            'post', $post, 'update_threadmark', array('old_label' => $existingThreadmark['label'], 'new_label' => $label), $thread
+          );
         }
       } else {
         if (!$threadmarksModel->canAddThreadmark($post, $thread, $forum)) {
@@ -43,7 +47,9 @@ class Sidane_Threadmarks_ControllerPublic_Post extends XFCP_Sidane_Threadmarks_C
         }
         $threadmarksModel->setThreadMark($thread['thread_id'], $post['post_id'], $label);
         $phrase = 'threadmark_created';
-        XenForo_Model_Log::logModeratorAction('post', $post, 'create_threadmark', array(), $thread);
+        XenForo_Model_Log::logModeratorAction(
+          'post', $post, 'create_threadmark', array('label' => $label), $thread
+        );
       }
 
       $controllerResponse = $this->getPostSpecificRedirect($post, $thread);


### PR DESCRIPTION
The moderator log wasn't recording the threadmark label (old and new when updating).

Now it looks like:

![Moderator log](http://f.cl.ly/items/2N2K0U2j2p333t0U3C2E/moderator-log.png)
