### PR TITLE
Improve handling of Threadmarks migrating between threads.

### DIFF
--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="sidaneThreadmarks" title="Threadmarks" version_string="1.1.2" version_id="5" url="https://xenforo.com/community/resources/threadmarks.3939/" install_callback_class="Sidane_Threadmarks_Install" install_callback_method="install" uninstall_callback_class="Sidane_Threadmarks_Install" uninstall_callback_method="uninstall">
+<addon addon_id="sidaneThreadmarks" title="Threadmarks" version_string="1.1.2" version_id="6" url="https://xenforo.com/community/resources/threadmarks.3939/" install_callback_class="Sidane_Threadmarks_Install" install_callback_method="install" uninstall_callback_class="Sidane_Threadmarks_Install" uninstall_callback_method="uninstall">
   <admin_navigation/>
   <admin_permissions/>
   <admin_style_properties/>

--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -265,9 +265,7 @@ $0]]></replace>
     </modification>
     <modification template="thread_view" modification_key="sidaneThreadmarksCss" description="Add threadmarks CSS to threads with threadmarks" execution_order="10" enabled="1" action="str_replace">
       <find><![CDATA[<xen:container var="$head.canonical">]]></find>
-      <replace><![CDATA[<xen:if is="{$thread.threadmark_count} > 0">
-  <xen:require css="threadmarks.css"/>
-</xen:if>
+      <replace><![CDATA[<xen:require css="threadmarks.css"/>
 $0]]></replace>
     </modification>
     <modification template="thread_view" modification_key="sidaneThreadmarksMenuOnSinglePageThreads" description="Display threadmarks menu on single page threads" execution_order="10" enabled="1" action="str_replace">

--- a/upload/library/Sidane/Threadmarks/ControllerPublic/Post.php
+++ b/upload/library/Sidane/Threadmarks/ControllerPublic/Post.php
@@ -11,7 +11,7 @@ class Sidane_Threadmarks_ControllerPublic_Post extends XFCP_Sidane_Threadmarks_C
     list($post, $thread, $forum) = $ftpHelper->assertPostValidAndViewable($postId);
 
     $threadmarksModel = $this->_getThreadmarksModel();
-    $existingThreadmark = $threadmarksModel->getByThreadIdAndPostId($thread['thread_id'], $post['post_id']);
+    $existingThreadmark = $threadmarksModel->getByPostId( $post['post_id']);
 
     if ($this->_request->isPost())
     {

--- a/upload/library/Sidane/Threadmarks/DataWriter/Post.php
+++ b/upload/library/Sidane/Threadmarks/DataWriter/Post.php
@@ -8,7 +8,7 @@ class Sidane_Threadmarks_DataWriter_Post extends XFCP_Sidane_Threadmarks_DataWri
 
     if ($this->isChanged('message_state'))
     {
-      $threadmark = $this->_getThreadMarkModel()->getByThreadIdAndPostId($this->get('thread_id'), $this->get('post_id'));
+      $threadmark = $this->_getThreadMarkModel()->getByPostId($this->get('post_id'));
 
       if (!empty($threadmark))
       {
@@ -28,7 +28,7 @@ class Sidane_Threadmarks_DataWriter_Post extends XFCP_Sidane_Threadmarks_DataWri
   {
     parent::_messagePostDelete();
 
-    $threadmark = $this->_getThreadMarkModel()->getByThreadIdAndPostId($this->get('thread_id'), $this->get('post_id'));
+    $threadmark = $this->_getThreadMarkModel()->getByPostId($this->get('post_id'));
     if (!empty($threadmark))
     {
       $decrementCount = ($this->isUpdate() && $this->getExisting('message_state') == 'visible');

--- a/upload/library/Sidane/Threadmarks/Install.php
+++ b/upload/library/Sidane/Threadmarks/Install.php
@@ -20,6 +20,7 @@ class Sidane_Threadmarks_Install
           post_id INT UNSIGNED NOT NULL,
           label VARCHAR(255) NOT NULL,
           UNIQUE KEY `thread_post_id` (`thread_id`,`post_id`)
+          UNIQUE KEY `post_id` (`post_id`)
         ) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci
       ");
       $tables_created = true;
@@ -75,6 +76,11 @@ class Sidane_Threadmarks_Install
     if ($version < 3)
     {
       self::modifyColumn('threadmarks', 'label', 'varchar(100)', 'VARCHAR(255) NOT NULL');
+    }
+
+    if ($version < 5)
+    {
+      self::addIndex('threadmarks', 'post_id', array('thread_id','post_id'));
     }
 
     XenForo_Application::defer('Sidane_Threadmarks_Deferred_Cache', array(), null, true);

--- a/upload/library/Sidane/Threadmarks/Install.php
+++ b/upload/library/Sidane/Threadmarks/Install.php
@@ -19,7 +19,7 @@ class Sidane_Threadmarks_Install
           thread_id INT UNSIGNED NOT NULL,
           post_id INT UNSIGNED NOT NULL,
           label VARCHAR(255) NOT NULL,
-          UNIQUE KEY `thread_post_id` (`thread_id`,`post_id`)
+          UNIQUE KEY `thread_post_id` (`thread_id`,`post_id`),
           UNIQUE KEY `post_id` (`post_id`)
         ) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci
       ");

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -17,7 +17,7 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
           threadmarks.threadmark_id, threadmarks.label as threadmark_label';
         $joinOptions['joinTables'] .= '
           LEFT JOIN threadmarks  ON
-          (threadmarks.thread_id = post.thread_id && threadmarks.post_id = post.post_id)';        
+            threadmarks.post_id = post.post_id';
       }
     }
 

--- a/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
@@ -110,6 +110,7 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
       VALUES
         (?, ?, ?)
       ON DUPLICATE KEY UPDATE
+        thread_id = values(thread_id),
         label = values(label)
     ', array($thread_id, $post_id, $label));
     $rowsAffected = $stmt->rowCount();
@@ -221,13 +222,12 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
     ",$limit, $offset), 'post_id', $threadId);
   }
 
-  public function getByThreadIdAndPostId($threadId, $postId) {
+  public function getByPostId($postId) {
     return $this->_getDb()->fetchRow("
       SELECT *
       FROM threadmarks
-      WHERE thread_id = ?
-        AND post_id = ?
-    ", array($threadId, $postId));
+      WHERE post_id = ?
+    ", array($postId));
   }
 
   public function getByThreadIdWithPostDate($threadId) {


### PR DESCRIPTION
Should help issue #30 by ensuring the threadmark doesn't disappear until the affected threads are made consistent.
