### PR TITLE
Initial work for threadmark edit history.

### DIFF
--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -61,6 +61,7 @@
     <phrase title="threadmarks_for" version_id="1" version_string="1.0"><![CDATA[Threadmarks for]]></phrase>
     <phrase title="threadmark_created" version_id="1" version_string="1.0"><![CDATA[Threadmark created]]></phrase>
     <phrase title="threadmark_deleted" version_id="1" version_string="1.0"><![CDATA[Threadmark deleted]]></phrase>
+    <phrase title="threadmark_history" version_id="9" version_string="1.1.6"><![CDATA[History]]></phrase>
     <phrase title="threadmark_label" version_id="1" version_string="1.0"><![CDATA[Threadmark label]]></phrase>
     <phrase title="threadmark_updated" version_id="1" version_string="1.0"><![CDATA[Threadmark updated]]></phrase>
     <phrase title="update_threadmark" version_id="1" version_string="1.0"><![CDATA[Update Threadmark]]></phrase>
@@ -201,7 +202,7 @@
 
   <div class="sectionFooter overlayOnly"><a class="button primary OverlayCloser">{xen:phrase close}</a></div>
 </div>]]></template>
-    <template title="threadmarks.css" version_id="3" version_string="1.0"><![CDATA[.PageNav.threadmarksSinglePage {
+    <template title="threadmarks.css" version_id="9" version_string="1.1.6"><![CDATA[.PageNav.threadmarksSinglePage {
   float: left;
   min-width: 0;
 }
@@ -237,6 +238,9 @@
   border-top-right-radius: 4px;
 }
 
+.threadmarker .history {
+}
+
 .threadmarker .label strong {
   color: {xen:property secondaryMedium};
   font-weight: bold;
@@ -251,9 +255,14 @@
   }
 }
 </xen:if>]]></template>
-    <template title="threadmarks_render_flag" version_id="3" version_string="1.0"><![CDATA[<xen:if is="{$threadmark} and {$post.canViewThreadmarks}">
+    <template title="threadmarks_render_flag" version_id="9" version_string="1.1.6"><![CDATA[<xen:if is="{$threadmark} and {$post.canViewThreadmarks}">
   <div class="threadmarker">
     <span class="label"><strong>{xen:phrase threadmark}:</strong> {$threadmark.label}</span>
+    <xen:if is="{$threadmark.edit_count} && {$post.canEditThreadmarks}">
+	  <span class="title_history ToggleTriggerAnchor">
+		  <a href="{xen:link posts/threadmarkHistory, $post}" class="item control ToggleTrigger history" data-cacheOverlay="false"><span></span>{xen:phrase threadmark_history}</a>
+      </span>
+    </xen:if>
   </div>
 </xen:if>]]></template>
   </templates>

--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="sidaneThreadmarks" title="Threadmarks" version_string="1.1.5" version_id="8" url="https://xenforo.com/community/resources/threadmarks.3939/" install_callback_class="Sidane_Threadmarks_Install" install_callback_method="install" uninstall_callback_class="Sidane_Threadmarks_Install" uninstall_callback_method="uninstall">
+<addon addon_id="sidaneThreadmarks" title="Threadmarks" version_string="1.1.6" version_id="9" url="https://xenforo.com/community/resources/threadmarks.3939/" install_callback_class="Sidane_Threadmarks_Install" install_callback_method="install" uninstall_callback_class="Sidane_Threadmarks_Install" uninstall_callback_method="uninstall">
   <admin_navigation/>
   <admin_permissions/>
   <admin_style_properties/>

--- a/upload/library/Sidane/Threadmarks/ControllerPublic/Post.php
+++ b/upload/library/Sidane/Threadmarks/ControllerPublic/Post.php
@@ -82,6 +82,13 @@ class Sidane_Threadmarks_ControllerPublic_Post extends XFCP_Sidane_Threadmarks_C
     }
   }
 
+  public function actionThreadmarkHistory()
+  {
+    $this->_request->setParam('content_type', 'threadmark');
+    $this->_request->setParam('content_id', $this->_input->filterSingle('post_id', XenForo_Input::UINT));
+    return $this->responseReroute('XenForo_ControllerPublic_EditHistory', 'index');
+  }
+
   protected function _getThreadmarksModel() {
     return $this->getModelFromCache('Sidane_Threadmarks_Model_Threadmarks');
   }

--- a/upload/library/Sidane/Threadmarks/DataWriter/Post.php
+++ b/upload/library/Sidane/Threadmarks/DataWriter/Post.php
@@ -9,17 +9,12 @@ class Sidane_Threadmarks_DataWriter_Post extends XFCP_Sidane_Threadmarks_DataWri
     if ($this->isChanged('message_state'))
     {
       $threadmark = $this->_getThreadMarkModel()->getByPostId($this->get('post_id'));
-
       if (!empty($threadmark))
       {
-        if ($this->get('message_state') == 'visible')
-        {
-          $this->_getThreadMarkModel()->modifyThreadMarkCount($this->get('thread_id'), 1);
-        }
-        else if ($this->isUpdate() && $this->getExisting('message_state') == 'visible')
-        {
-          $this->_getThreadMarkModel()->modifyThreadMarkCount($this->get('thread_id'), -1);
-        }
+        $dw = XenForo_DataWriter::create("Sidane_Threadmarks_DataWriter_Threadmark");
+        $dw->setExistingData($threadmark['threadmark_id']);
+        $dw->set('message_state', $this->get('message_state'));
+        $dw->save();
       }
     }
   }
@@ -31,8 +26,9 @@ class Sidane_Threadmarks_DataWriter_Post extends XFCP_Sidane_Threadmarks_DataWri
     $threadmark = $this->_getThreadMarkModel()->getByPostId($this->get('post_id'));
     if (!empty($threadmark))
     {
-      $decrementCount = ($this->isUpdate() && $this->getExisting('message_state') == 'visible');
-      $this->_getThreadMarkModel()->deleteThreadMark($threadmark, $decrementCount);
+      $dw = XenForo_DataWriter::create("Sidane_Threadmarks_DataWriter_Threadmark");
+      $dw->setExistingData($threadmark['threadmark_id']);
+      $dw->delete();
     }
   }
 

--- a/upload/library/Sidane/Threadmarks/DataWriter/Threadmark.php
+++ b/upload/library/Sidane/Threadmarks/DataWriter/Threadmark.php
@@ -1,0 +1,136 @@
+<?php
+
+class Sidane_Threadmarks_DataWriter_Threadmark extends XenForo_DataWriter
+{
+
+  protected function _getFields()
+  {
+    return array(
+      'threadmarks' => array(
+        'threadmark_id'          => array('type' => self::TYPE_UINT, 'autoIncrement' => true),
+        'user_id'                => array('type' => self::TYPE_UINT, 'required' => true),
+        'post_date'              => array('type' => self::TYPE_UINT, 'required' => true, 'default' => XenForo_Application::$time),
+        'thread_id'              => array('type' => self::TYPE_UINT, 'required' => true),
+        'post_id'                => array('type' => self::TYPE_UINT, 'required' => true),
+        'label'                  => array('type' => self::TYPE_STRING, 'required' => true, 'maxLength' => 75,
+             'requiredError' => 'please_enter_label_for_threadmark'
+        ),
+        'message_state'          => array('type' => self::TYPE_STRING, 'default' => 'visible',
+          'allowedValues' => array('visible', 'moderated', 'deleted')
+        ),
+        'last_edit_date'         => array('type' => self::TYPE_UINT, 'default' => 0),
+        'last_edit_user_id'      => array('type' => self::TYPE_UINT, 'default' => 0),
+        'edit_count'             => array('type' => self::TYPE_UINT_FORCED, 'default' => 0),
+        'position'               => array('type' => self::TYPE_UINT_FORCED),
+      )
+    );
+  }
+
+  protected function _getExistingData($data)
+  {
+    if (!$threadmark_id = $this->_getExistingPrimaryKey($data, 'threadmark_id'))
+    {
+      return false;
+    }
+
+    return array('threadmarks' => $this->_getThreadmarksModel()->getThreadMarkById($threadmark_id));
+  }
+
+  protected function _getUpdateCondition($tableName)
+  {
+    return 'threadmark_id = ' . $this->_db->quote($this->getExisting('threadmark_id'));
+  }
+
+  protected function _preSave()
+  {
+    parent::_preSave();
+
+    if ($this->isUpdate() && $this->isChanged('label'))
+    {
+      $this->set('last_edit_date', XenForo_Application::$time);
+      $this->set('last_edit_user_id', XenForo_Visitor::getUserId());
+      $this->set('edit_count', $this->get('edit_count') + 1);
+    }
+  }
+
+  protected function _postSave()
+  {
+    if ($this->isUpdate())
+    {
+      if ($this->isChanged('label'))
+      {
+        $this->_insertEditHistory();
+      }
+    }
+    else if ($this->isInsert())
+    {
+    }
+
+    if($this->isChanged('message_state'))
+    {
+      $this->_updateThreadMarkCount();
+    }
+
+    parent::_postSave();
+  }
+
+  protected function _postDelete()
+  {
+    parent::_postDelete();
+
+    $this->getModelFromCache('XenForo_Model_EditHistory')->deleteEditHistoryForContent(
+      $this->getContentType(), $this->getContentId()
+    );
+
+    $this->_updateThreadMarkCount(true);
+  }
+
+  protected function getContentType()
+  {
+    return 'threadmark';
+  }
+
+  protected function getContentId()
+  {
+    return $this->get('post_id');
+  }
+
+  protected function _updateThreadMarkCount($isDelete = false)
+  {
+    if ($this->getExisting('message_state') == 'visible'
+      && ($this->get('message_state') != 'visible' || $isDelete)
+    )
+    {
+      $this->_db->query('
+        UPDATE xf_thread
+        SET threadmark_count = IF(threadmark_count > 0, threadmark_count - 1, 0)
+        WHERE thread_id = ?
+      ', $this->get('thread_id'));
+    }
+    else if ($this->get('message_state') == 'visible' && $this->getExisting('message_state') != 'visible')
+    {
+      $this->_db->query('
+        UPDATE xf_thread
+        SET threadmark_count = threadmark_count + 1
+        WHERE thread_id = ?
+      ', $this->get('thread_id'));
+    }
+  }
+
+  protected function _insertEditHistory()
+  {
+    $historyDw = XenForo_DataWriter::create('XenForo_DataWriter_EditHistory', XenForo_DataWriter::ERROR_SILENT);
+    $historyDw->bulkSet(array(
+        'content_type' => $this->getContentType(),
+        'content_id' => $this->getContentId(),
+        'edit_user_id' => XenForo_Visitor::getUserId(),
+        'old_text' => $this->getExisting('label')
+    ));
+    $historyDw->save();
+  }
+
+  protected function _getThreadmarksModel()
+  {
+    return $this->getModelFromCache('Sidane_Threadmarks_Model_Threadmarks');
+  }
+}

--- a/upload/library/Sidane/Threadmarks/DataWriter/Threadmark.php
+++ b/upload/library/Sidane/Threadmarks/DataWriter/Threadmark.php
@@ -12,7 +12,7 @@ class Sidane_Threadmarks_DataWriter_Threadmark extends XenForo_DataWriter
         'post_date'              => array('type' => self::TYPE_UINT, 'required' => true, 'default' => XenForo_Application::$time),
         'thread_id'              => array('type' => self::TYPE_UINT, 'required' => true),
         'post_id'                => array('type' => self::TYPE_UINT, 'required' => true),
-        'label'                  => array('type' => self::TYPE_STRING, 'required' => true, 'maxLength' => 75,
+        'label'                  => array('type' => self::TYPE_STRING, 'required' => true, 'maxLength' => 255,
              'requiredError' => 'please_enter_label_for_threadmark'
         ),
         'message_state'          => array('type' => self::TYPE_STRING, 'default' => 'visible',

--- a/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
+++ b/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
@@ -1,0 +1,103 @@
+<?php
+
+class SV_TitleEditHistory_EditHistoryHandler_Thread extends XenForo_EditHistoryHandler_Abstract
+{
+    protected $_prefix = 'threadmark';
+
+    protected function _getContent($contentId, array $viewingUser)
+    {
+        /* @var $postModel XenForo_Model_Post */
+        $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
+
+        $threadmark = $threadmarkModel->getThreadById($contentId, array(
+            'join' => XenForo_Model_Thread::FETCH_FORUM | XenForo_Model_Thread::FETCH_USER,
+            'permissionCombinationId' => $viewingUser['permission_combination_id']
+        ));
+        if ($threadmark)
+        {
+            $threadmark['permissions'] = XenForo_Permission::unserializePermissions($threadmark['node_permission_cache']);
+        }
+
+        return $threadmark;
+    }
+
+    protected function _canViewHistoryAndContent(array $content, array $viewingUser)
+    {
+        $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
+
+        return $threadmarkModel->canEditThreadTitle($content, $content, $null);
+    }
+
+    protected function _canRevertContent(array $content, array $viewingUser)
+    {
+        $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
+
+        return $threadmarkModel->canEditThreadTitle($content, $content, $null);
+    }
+
+    public function getText(array $content)
+    {
+        return htmlspecialchars($content['label']);
+    }
+
+    public function getTitle(array $content)
+    {
+        //return new XenForo_Phrase('post_in_thread_x', array('label' => $content['label']));
+        return htmlspecialchars($content['label']); // TODO
+    }
+
+    public function getBreadcrumbs(array $content)
+    {
+        /* @var $nodeModel XenForo_Model_Node */
+        $nodeModel = XenForo_Model::create('XenForo_Model_Node');
+
+        $node = $nodeModel->getNodeById($content['node_id']);
+        if ($node)
+        {
+            $crumb = $nodeModel->getNodeBreadCrumbs($node);
+            $crumb[] = array(
+                'href' => XenForo_Link::buildPublicLink('full:threads', $content),
+                'value' => $content['label']
+            );
+            return $crumb;
+        }
+        else
+        {
+            return array();
+        }
+    }
+
+    public function getNavigationTab()
+    {
+        return 'forums';
+    }
+
+    public function formatHistory($string, XenForo_View $view)
+    {
+        return htmlspecialchars($string);
+    }
+
+    public function revertToVersion(array $content, $revertCount, array $history, array $previous = null)
+    {
+        $dw = XenForo_DataWriter::create('Sidane_Threadmarks_DataWriter_Threadmark', XenForo_DataWriter::ERROR_SILENT);
+        $dw->setExistingData($content);
+        $dw->set('label', $history['old_text']);
+        $dw->set('edit_count', $dw->get('edit_count') + 1);
+        if ($dw->get('edit_count'))
+        {
+            if (!$previous || $previous['edit_user_id'] != $content['user_id'])
+            {
+                // if previous is a mod edit, don't show as it may have been hidden
+                $dw->set('last_edit_date', 0);
+            }
+            else if ($previous && $previous['thread_title_edit_user_id'] == $content['user_id'])
+            {
+                $dw->set('edit_date', $previous['edit_date']);
+                $dw->set('edit_user_id', $previous['edit_user_id']);
+            }
+        }
+
+        return $dw->save();
+    }
+
+}

--- a/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
+++ b/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
@@ -40,7 +40,6 @@ class Sidane_Threadmarks_EditHistoryHandler_Threadmark extends XenForo_EditHisto
 
     public function getTitle(array $content)
     {
-      //return new XenForo_Phrase('post_in_thread_x', array('label' => $content['label']));
       return htmlspecialchars($content['label']); // TODO
     }
 

--- a/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
+++ b/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
@@ -9,18 +9,23 @@ class Sidane_Threadmarks_EditHistoryHandler_Threadmark extends XenForo_EditHisto
       /* @var $postModel XenForo_Model_Post */
       $postModel = XenForo_Model::create('XenForo_Model_Post');
       $post = $postModel->getPostById($contentId, array(
-        'join' => XenForo_Model_Post::FETCH_FORUM | XenForo_Model_Post::FETCH_THREAD | XenForo_Model_Post::FETCH_USER |  Sidane_Threadmarks_Model_Post::FETCH_THREADMARKS,
+        'join' => XenForo_Model_Post::FETCH_FORUM | XenForo_Model_Post::FETCH_THREAD | XenForo_Model_Post::FETCH_USER |  Sidane_Threadmarks_Model_Post::FETCH_THREADMARKS_FULL,
         'permissionCombinationId' => $viewingUser['permission_combination_id']
       ));
       if ($post)
       {
         $post['permissions'] = XenForo_Permission::unserializePermissions($post['node_permission_cache']);
-        $post['label'] = $post['threadmark_label'];
-        $post['edit_count'] = $post['threadmark_edit_count'];
-        $post['user_id'] = $post['threadmark_user_id'];
-        unset($post['threadmark_label']);
-        unset($post['threadmark_edit_count']);
-        unset($post['threadmark_user_id']);
+        $prefix = 'threadmark';
+        $remap = array('label', 'edit_count', 'user_id', 'username', 'last_edit_date', 'last_edit_user_id');
+        foreach($remap as $remapItem)
+        {
+          $key = $prefix .'_'. $remapItem;
+          if (isset($post[$key]))
+          {
+            $post[$remapItem] = $post[$key];
+            unset($post[$key]);
+          }
+        }
       }      
       return $post;
     }
@@ -92,10 +97,10 @@ class Sidane_Threadmarks_EditHistoryHandler_Threadmark extends XenForo_EditHisto
           // if previous is a mod edit, don't show as it may have been hidden
           $dw->set('last_edit_date', 0);
         }
-        else if ($previous && $previous['thread_title_edit_user_id'] == $content['user_id'])
+        else if ($previous && $previous['edit_user_id'] == $content['user_id'])
         {
-          $dw->set('edit_date', $previous['edit_date']);
-          $dw->set('edit_user_id', $previous['edit_user_id']);
+          $dw->set('last_edit_date', $previous['edit_date']);
+          $dw->set('last_edit_user_id', $previous['edit_user_id']);
         }
       }
 

--- a/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
+++ b/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
@@ -15,17 +15,8 @@ class Sidane_Threadmarks_EditHistoryHandler_Threadmark extends XenForo_EditHisto
       if ($post)
       {
         $post['permissions'] = XenForo_Permission::unserializePermissions($post['node_permission_cache']);
-        $prefix = 'threadmark';
-        $remap = array('label', 'edit_count', 'user_id', 'username', 'last_edit_date', 'last_edit_user_id');
-        foreach($remap as $remapItem)
-        {
-          $key = $prefix .'_'. $remapItem;
-          if (isset($post[$key]))
-          {
-            $post[$remapItem] = $post[$key];
-            unset($post[$key]);
-          }
-        }
+        $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
+        $threadmarkModel->remapThreadmark($post,$post);
       }      
       return $post;
     }

--- a/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
+++ b/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
@@ -24,7 +24,10 @@ class Sidane_Threadmarks_EditHistoryHandler_Threadmark extends XenForo_EditHisto
     protected function _canViewHistoryAndContent(array $content, array $viewingUser)
     {
       $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
-      return $threadmarkModel->canViewThreadmark($content, $null, $content['permissions'], $viewingUser);
+      $postModel = XenForo_Model::create('XenForo_Model_Post');
+      return $postModel->canViewPostAndContainer($content, $content, $content, $null, $content['permissions'], $viewingUser) &&
+             $postModel->canViewPostHistory($content, $content, $content, $null, $content['permissions'], $viewingUser) &&
+             $threadmarkModel->canViewThreadmark($content, $null, $content['permissions'], $viewingUser);
     }
 
     protected function _canRevertContent(array $content, array $viewingUser)

--- a/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
+++ b/upload/library/Sidane/Threadmarks/EditHistoryHandler/Threadmark.php
@@ -1,103 +1,104 @@
 <?php
 
-class SV_TitleEditHistory_EditHistoryHandler_Thread extends XenForo_EditHistoryHandler_Abstract
+class Sidane_Threadmarks_EditHistoryHandler_Threadmark extends XenForo_EditHistoryHandler_Abstract
 {
-    protected $_prefix = 'threadmark';
+    protected $_prefix = 'posts';
 
     protected function _getContent($contentId, array $viewingUser)
     {
-        /* @var $postModel XenForo_Model_Post */
-        $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
-
-        $threadmark = $threadmarkModel->getThreadById($contentId, array(
-            'join' => XenForo_Model_Thread::FETCH_FORUM | XenForo_Model_Thread::FETCH_USER,
-            'permissionCombinationId' => $viewingUser['permission_combination_id']
-        ));
-        if ($threadmark)
-        {
-            $threadmark['permissions'] = XenForo_Permission::unserializePermissions($threadmark['node_permission_cache']);
-        }
-
-        return $threadmark;
+      /* @var $postModel XenForo_Model_Post */
+      $postModel = XenForo_Model::create('XenForo_Model_Post');
+      $post = $postModel->getPostById($contentId, array(
+        'join' => XenForo_Model_Post::FETCH_FORUM | XenForo_Model_Post::FETCH_THREAD | XenForo_Model_Post::FETCH_USER |  Sidane_Threadmarks_Model_Post::FETCH_THREADMARKS,
+        'permissionCombinationId' => $viewingUser['permission_combination_id']
+      ));
+      if ($post)
+      {
+        $post['permissions'] = XenForo_Permission::unserializePermissions($post['node_permission_cache']);
+        $post['label'] = $post['threadmark_label'];
+        $post['edit_count'] = $post['threadmark_edit_count'];
+        $post['user_id'] = $post['threadmark_user_id'];
+        unset($post['threadmark_label']);
+        unset($post['threadmark_edit_count']);
+        unset($post['threadmark_user_id']);
+      }      
+      return $post;
     }
 
     protected function _canViewHistoryAndContent(array $content, array $viewingUser)
     {
-        $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
-
-        return $threadmarkModel->canEditThreadTitle($content, $content, $null);
+      $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
+      return $threadmarkModel->canViewThreadmark($content, $null, $content['permissions'], $viewingUser);
     }
 
     protected function _canRevertContent(array $content, array $viewingUser)
     {
-        $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
-
-        return $threadmarkModel->canEditThreadTitle($content, $content, $null);
+      $threadmarkModel = XenForo_Model::create('Sidane_Threadmarks_Model_Threadmarks');
+      return $threadmarkModel->canEditThreadmark($content, $content, $content, $null, $content['permissions'], $viewingUser);
     }
 
     public function getText(array $content)
     {
-        return htmlspecialchars($content['label']);
+      return htmlspecialchars($content['label']);
     }
 
     public function getTitle(array $content)
     {
-        //return new XenForo_Phrase('post_in_thread_x', array('label' => $content['label']));
-        return htmlspecialchars($content['label']); // TODO
+      //return new XenForo_Phrase('post_in_thread_x', array('label' => $content['label']));
+      return htmlspecialchars($content['label']); // TODO
     }
 
     public function getBreadcrumbs(array $content)
     {
-        /* @var $nodeModel XenForo_Model_Node */
-        $nodeModel = XenForo_Model::create('XenForo_Model_Node');
+      /* @var $nodeModel XenForo_Model_Node */
+      $nodeModel = XenForo_Model::create('XenForo_Model_Node');
 
-        $node = $nodeModel->getNodeById($content['node_id']);
-        if ($node)
-        {
-            $crumb = $nodeModel->getNodeBreadCrumbs($node);
-            $crumb[] = array(
-                'href' => XenForo_Link::buildPublicLink('full:threads', $content),
-                'value' => $content['label']
-            );
-            return $crumb;
-        }
-        else
-        {
-            return array();
-        }
+      $node = $nodeModel->getNodeById($content['node_id']);
+      if ($node)
+      {
+        $crumb = $nodeModel->getNodeBreadCrumbs($node);
+        $crumb[] = array(
+          'href' => XenForo_Link::buildPublicLink('full:threads', $content),
+          'value' => $content['label']
+        );
+        return $crumb;
+      }
+      else
+      {
+        return array();
+      }
     }
 
     public function getNavigationTab()
     {
-        return 'forums';
+      return 'forums';
     }
 
     public function formatHistory($string, XenForo_View $view)
     {
-        return htmlspecialchars($string);
+      return htmlspecialchars($string);
     }
 
     public function revertToVersion(array $content, $revertCount, array $history, array $previous = null)
     {
-        $dw = XenForo_DataWriter::create('Sidane_Threadmarks_DataWriter_Threadmark', XenForo_DataWriter::ERROR_SILENT);
-        $dw->setExistingData($content);
-        $dw->set('label', $history['old_text']);
-        $dw->set('edit_count', $dw->get('edit_count') + 1);
-        if ($dw->get('edit_count'))
+      $dw = XenForo_DataWriter::create('Sidane_Threadmarks_DataWriter_Threadmark' , XenForo_DataWriter::ERROR_SILENT);
+      $dw->setExistingData($content['threadmark_id']);
+      $dw->set('label', $history['old_text']);
+      $dw->set('edit_count', $dw->get('edit_count') + 1);
+      if ($dw->get('edit_count'))
+      {
+        if (!$previous || $previous['edit_user_id'] != $content['user_id'])
         {
-            if (!$previous || $previous['edit_user_id'] != $content['user_id'])
-            {
-                // if previous is a mod edit, don't show as it may have been hidden
-                $dw->set('last_edit_date', 0);
-            }
-            else if ($previous && $previous['thread_title_edit_user_id'] == $content['user_id'])
-            {
-                $dw->set('edit_date', $previous['edit_date']);
-                $dw->set('edit_user_id', $previous['edit_user_id']);
-            }
+          // if previous is a mod edit, don't show as it may have been hidden
+          $dw->set('last_edit_date', 0);
         }
+        else if ($previous && $previous['thread_title_edit_user_id'] == $content['user_id'])
+        {
+          $dw->set('edit_date', $previous['edit_date']);
+          $dw->set('edit_user_id', $previous['edit_user_id']);
+        }
+      }
 
-        return $dw->save();
+      return $dw->save();
     }
-
 }

--- a/upload/library/Sidane/Threadmarks/Install.php
+++ b/upload/library/Sidane/Threadmarks/Install.php
@@ -22,7 +22,7 @@ class Sidane_Threadmarks_Install
           post_date int not null default 0,
           position int not null default 0,
           message_state enum('visible','moderated','deleted') NOT NULL DEFAULT 'visible',
-          edit_count int not null default 0',
+          edit_count int not null default 0,
           last_edit_date int not null default 0,
           last_edit_user_id int not null default 0,
           label VARCHAR(255) NOT NULL,

--- a/upload/library/Sidane/Threadmarks/Install.php
+++ b/upload/library/Sidane/Threadmarks/Install.php
@@ -27,8 +27,8 @@ class Sidane_Threadmarks_Install
           last_edit_user_id int not null default 0,
           label VARCHAR(255) NOT NULL,
           UNIQUE KEY `thread_post_id` (`thread_id`,`post_id`),
-          UNIQUE KEY `thread_position` (`thread_id`,`position`),
-          UNIQUE KEY `user_id` (`user_id`),
+          KEY `thread_position` (`thread_id`,`position`),
+          KEY `user_id` (`user_id`),
           UNIQUE KEY `post_id` (`post_id`)
         ) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci
       ");

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -14,7 +14,7 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
       if ($fetchOptions['join'] & Sidane_Threadmarks_Model_Post::FETCH_THREADMARKS)
       {
         $joinOptions['selectFields'] .= ',
-          threadmarks.threadmark_id, threadmarks.label as threadmark_label
+          threadmarks.threadmark_id, threadmarks.label as threadmark_label, threadmarks.edit_count as threadmark_edit_count
         ';
         $joinOptions['joinTables'] .= '
           LEFT JOIN threadmarks  ON
@@ -42,9 +42,11 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
       (
         'threadmark_id' => $post['threadmark_id'],
         'label' => $post['threadmark_label'],
+        'edit_count' => $post['threadmark_edit_count'],
       );
       unset($post['threadmark_id']);
       unset($post['threadmark_label']);
+      unset($post['threadmark_edit_count']);
     }
 
     return $post;

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -14,7 +14,8 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
       if ($fetchOptions['join'] & Sidane_Threadmarks_Model_Post::FETCH_THREADMARKS)
       {
         $joinOptions['selectFields'] .= ',
-          threadmarks.threadmark_id, threadmarks.label as threadmark_label, threadmarks.edit_count as threadmark_edit_count
+          threadmarks.threadmark_id, threadmarks.label as threadmark_label, threadmarks.edit_count as threadmark_edit_count,
+          threadmarks.user_id as threadmark_user_id
         ';
         $joinOptions['joinTables'] .= '
           LEFT JOIN threadmarks  ON
@@ -43,8 +44,10 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
         'threadmark_id' => $post['threadmark_id'],
         'label' => $post['threadmark_label'],
         'edit_count' => $post['threadmark_edit_count'],
+        'user_id' => $post['threadmark_user_id'],
       );
       unset($post['threadmark_id']);
+      unset($post['threadmark_user_id']);
       unset($post['threadmark_label']);
       unset($post['threadmark_edit_count']);
     }

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -54,18 +54,9 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
     $post['canViewThreadmarks'] = $threadmarkmodel->canViewThreadmark($thread, $null, $nodePermissions, $viewingUser);
 
     if (!empty($post['threadmark_id']))
-    {    
-      $post['threadmark'] = array
-      (
-        'threadmark_id' => $post['threadmark_id'],
-        'label' => $post['threadmark_label'],
-        'edit_count' => $post['threadmark_edit_count'],
-        'user_id' => $post['threadmark_user_id'],
-      );
-      unset($post['threadmark_id']);
-      unset($post['threadmark_user_id']);
-      unset($post['threadmark_label']);
-      unset($post['threadmark_edit_count']);
+    {
+      $post['threadmark'] = array('threadmark_id' => $post['threadmark_id']);
+      $threadmarkmodel->remapThreadmark($post, $post['threadmark']);
     }
 
     return $post;

--- a/upload/library/Sidane/Threadmarks/Model/Post.php
+++ b/upload/library/Sidane/Threadmarks/Model/Post.php
@@ -4,6 +4,7 @@
 class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
 {
   const FETCH_THREADMARKS = 0x80000; // hope this doesn't conflict
+  const FETCH_THREADMARKS_FULL = 0x180000; // this includes FETCH_THREADMARKS
 
   public function preparePostJoinOptions(array $fetchOptions)
   {
@@ -21,6 +22,21 @@ class Sidane_Threadmarks_Model_Post extends XFCP_Sidane_Threadmarks_Model_Post
           LEFT JOIN threadmarks  ON
             threadmarks.post_id = post.post_id
         ';
+
+        if (($fetchOptions['join'] & Sidane_Threadmarks_Model_Post::FETCH_THREADMARKS_FULL) == Sidane_Threadmarks_Model_Post::FETCH_THREADMARKS_FULL)
+        {
+          $joinOptions['selectFields'] .= ',
+            threadmarks.last_edit_date as threadmark_last_edit_date,
+            threadmarks.last_edit_user_id as threadmark_last_edit_user_id,
+            threadmarks.post_date as threadmark_post_date,
+            tm_user.username as threadmark_username
+          ';
+          
+          $joinOptions['joinTables'] .= '
+            LEFT JOIN xf_user tm_user  ON
+              tm_user.user_id = threadmarks.user_id
+          ';
+        }
       }
     }
 

--- a/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
@@ -236,4 +236,19 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
       ORDER BY threadmarks.position ASC
     ", 'post_id', $threadId);
   }
+  
+  public function remapThreadmark(array &$source, array &$dest)
+  {
+    $prefix = 'threadmark';
+    $remap = array('label', 'edit_count', 'user_id', 'username', 'last_edit_date', 'last_edit_user_id');
+    foreach($remap as $remapItem)
+    {
+      $key = $prefix .'_'. $remapItem;
+      if (isset($source[$key]))
+      {
+        $dest[$remapItem] = $source[$key];
+        unset($source[$key]);
+      }
+    }
+  }
 }

--- a/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/Model/Threadmarks.php
@@ -6,20 +6,20 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
   public function getMenuLimit(array $thread, array $nodePermissions = null, array $viewingUser = null)
   {
     $this->standardizeViewingUserReferenceForNode($thread['node_id'], $viewingUser, $nodePermissions);
-    
-    $menulimit = XenForo_Permission::hasContentPermission($nodePermissions, 'sidane_tm_menu_limit'); 
+
+    $menulimit = XenForo_Permission::hasContentPermission($nodePermissions, 'sidane_tm_menu_limit');
     if($menulimit > 0)
     {
       return $menulimit;
     }
-    
+
     return 0;
   }
-  
+
   public function canViewThreadmark(array $thread, &$errorPhraseKey = '', array $nodePermissions = null, array $viewingUser = null)
   {
     $this->standardizeViewingUserReferenceForNode($thread['node_id'], $viewingUser, $nodePermissions);
-  
+
     if (XenForo_Permission::hasContentPermission($nodePermissions, 'sidane_tm_manage'))
     {
       return true;
@@ -41,7 +41,7 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
     {
       return false;
     }
-    
+
     if (XenForo_Permission::hasContentPermission($nodePermissions, 'sidane_tm_manage'))
     {
       return true;
@@ -63,7 +63,7 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
     {
       return false;
     }
-    
+
     if (XenForo_Permission::hasContentPermission($nodePermissions, 'sidane_tm_manage'))
     {
       return true;
@@ -85,7 +85,7 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
     {
       return false;
     }
-    
+
     if (XenForo_Permission::hasContentPermission($nodePermissions, 'sidane_tm_manage'))
     {
       return true;
@@ -97,41 +97,51 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
     }
 
     return false;
-  } 
+  }
+
+  public function getThreadMarkById($id)
+  {
+    return $this->_getDb()->fetchRow("
+      SELECT *
+      FROM threadmarks
+      WHERE threadmark_id = ?
+    ", array($id));
+  }
 
   public function setThreadMark($thread_id, $post_id, $label) {
     $db = $this->_getDb();
 
     XenForo_Db::beginTransaction($db);
 
-    $stmt =  $db->query('
-      INSERT INTO threadmarks
-        (thread_id, post_id, label)
-      VALUES
-        (?, ?, ?)
-      ON DUPLICATE KEY UPDATE
-        thread_id = values(thread_id),
-        label = values(label)
-    ', array($thread_id, $post_id, $label));
-    $rowsAffected = $stmt->rowCount();
-
-    // http://dev.mysql.com/doc/refman/5.0/en/insert-on-duplicate.html
-    // 1 - new row, 2 - update
-    if ($rowsAffected == 1)
+    $threadmark = $this->getByPostId($post_id);
+    $dw = XenForo_DataWriter::create("Sidane_Threadmarks_DataWriter_Threadmark");
+    if (!empty($threadmark['threadmark_id']))
     {
-        $db->query('
-          UPDATE xf_thread
-          SET threadmark_count = threadmark_count + 1
-          WHERE thread_id = ?
-        ', $thread_id);
+      $dw->setExistingData($threadmark['threadmark_id']);
     }
+    else
+    {
+      $position  = $db->fetchOne("
+        SELECT position
+        FROM xf_post
+        where post_id = ?
+        limit 1
+      ", array($post_id));
+
+      $dw->set('user_id', XenForo_Visitor::getUserId());
+      $dw->set('post_id', $post_id);
+      $dw->set('position', $position);
+    }
+    $dw->set('thread_id', $thread_id);
+    $dw->set('label', $label);
+    $dw->save();
 
     XenForo_Db::commit($db);
 
     return true;
   }
 
-  public function deleteThreadMark($threadmark, $decrementCount = false)
+  public function deleteThreadMark($threadmark)
   {
     $db = $this->_getDb();
     if (empty($threadmark['threadmark_id']))
@@ -142,28 +152,13 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
 
     XenForo_Db::beginTransaction($db);
 
-    $db->query('
-        DELETE FROM threadmarks WHERE threadmark_id = ?
-    ', $threadmark['threadmark_id']);
-
-    if ($decrementCount && !empty($threadmark['thread_id']))
-    {
-        $this->modifyThreadMarkCount($threadmark['thread_id'], -1);
-    }
+    $dw = XenForo_DataWriter::create("Sidane_Threadmarks_DataWriter_Threadmark");
+    $dw->setExistingData($threadmark['threadmark_id']);
+    $dw->delete();
 
     XenForo_Db::commit($db);
 
     return true;
-  }
-
-  public function modifyThreadMarkCount($thread_id, $increment)
-  {
-    $db = $this->_getDb();
-    $db->query('
-        UPDATE xf_thread
-        SET threadmark_count = threadmark_count + ?
-        WHERE thread_id = ? and threadmark_count + ? >= 0
-    ', array($increment, $thread_id, $increment));
   }
 
   public function rebuildThreadMarkCache($thread_id)
@@ -177,13 +172,16 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
         LEFT JOIN xf_post AS post on post.post_id = threadmarks.post_id
         where `threadmarks`.thread_id = ? and post.post_id is null;
     ', $thread_id);
-    
-    // ensure each threadmark associated with the thread really is
+
+    // ensure each threadmark associated with the thread really is,
+    // and resync attributes off the xf_post table
     $db->query('
         update `threadmarks` marks
         join xf_post AS post on post.post_id = marks.post_id
         set marks.thread_id = post.thread_id
-        where (post.thread_id = ? or marks.thread_id = ?) and post.thread_id <> marks.thread_id;
+           ,marks.message_state = post.message_state
+           ,marks.position = post.position
+        where (post.thread_id = ? or marks.thread_id = ?);
     ', array($thread_id,$thread_id));
 
     // recompute threadmark totals
@@ -199,7 +197,7 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
 
   public function recalculatePositionsInThread($threadId)
   {
-    XenForo_Application::defer('Sidane_Threadmarks_Deferred_SingleThreadCache', array('threadId' => $threadId), null, true);    
+    XenForo_Application::defer('Sidane_Threadmarks_Deferred_SingleThreadCache', array('threadId' => $threadId), null, true);
   }
 
   public function getThreadIdsWithThreadMarks($limit =0, $offset = 0)
@@ -216,9 +214,8 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
     return $this->fetchAllKeyed($this->limitQueryResults("
       SELECT threadmarks.*
       FROM threadmarks
-      JOIN xf_post AS post ON post.post_id = threadmarks.post_id
-      WHERE threadmarks.thread_id = ? and post.message_state = 'visible'
-      ORDER BY post.position DESC
+      WHERE threadmarks.thread_id = ? and threadmarks.message_state = 'visible'
+      ORDER BY threadmarks.position DESC
     ",$limit, $offset), 'post_id', $threadId);
   }
 
@@ -235,8 +232,8 @@ class Sidane_Threadmarks_Model_Threadmarks extends XenForo_Model
       SELECT threadmarks.*, post.post_date
       FROM threadmarks
       JOIN xf_post AS post ON post.post_id = threadmarks.post_id
-      WHERE threadmarks.thread_id = ? and post.message_state = 'visible'
-      ORDER BY post.position ASC
+      WHERE threadmarks.thread_id = ? and threadmarks.message_state = 'visible'
+      ORDER BY threadmarks.position ASC
     ", 'post_id', $threadId);
   }
 }


### PR DESCRIPTION
This addresses parts of #25, with full edit history support and tracking of original ownership.

This is a fairly large change as I've switched to using Datawriters which simplified a bunch of complexity which was cropping up.

No history button yet, but the wire-up is simple; see [here](https://github.com/Xon/XenForo-TitleEditHistory/blob/master/addon-SV_TitleEditHistory.xml) for an example template modification with html+css

I would like to test this more for maybe a week or so before releasing it.  I've done upgrade tests, and add/edit/delete, view items work. 

Looking to have Searchable threadmarkers via the built-in search system based off this branch, with in the next day or so.
